### PR TITLE
MQXXX init logic

### DIFF
--- a/include/HMS_MQXXX_Config.h
+++ b/include/HMS_MQXXX_Config.h
@@ -366,6 +366,7 @@
 // Temperature Compensation (20°C baseline)
 #define HMS_MQXXX_TEMP_BASELINE             20.0f                    // Reference temperature (°C)
 #define HMS_MQXXX_TEMP_COEFF_GENERIC        0.004f                   // Generic temp coefficient (%/°C)
+#define HMS_CALIBRATIION_SAMPLES            5
 
 // MQ sensor-specific temperature coefficients
 #define HMS_MQXXX_MQ2_TEMP_COEFF            0.005f                   // Temperature coefficient (%/°C)
@@ -384,7 +385,7 @@
 #define HMS_MQXXX_MQ303A_HUMIDITY_COEFF     0.003f                   // Humidity coefficient (%/%RH) - Most affected
 
 // Simple compensation enable/disable (for easy on/off)
-#define HMS_MQXXX_ENABLE_TEMP_COMPENSATION  0                        // 1=enabled, 0=disabled
+#define HMS_MQXXX_ENABLE_ecTEMP_COMPENSATION  0                        // 1=enabled, 0=disabled
 #define HMS_MQXXX_ENABLE_HUMIDITY_COMPENSATION 0                     // 1=enabled, 0=disabled
 
 // Auto-select default values based on enabled sensor type

--- a/include/HMS_MQXXX_DRIVER.h
+++ b/include/HMS_MQXXX_DRIVER.h
@@ -95,7 +95,7 @@ class HMS_MQXXX {
     #if defined(HMS_MQXXX_PLATFORM_ARDUINO)
       HMS_MQXXX(uint8_t pin = A0, HMS_MQXXX_Type type = HMS_MQXXX_DEFAULT_TYPE);
     #elif defined(HMS_MQXXX_PLATFORM_STM32_HAL)
-      HMS_MQXXX(GPIO_TypeDef *port, uint32_t pin, HMS_MQXXX_Type type = HMS_MQXXX_DEFAULT_TYPE);
+      HMS_MQXXX(ADC_HandleTypeDef *hadc, HMS_MQXXX_Type type = HMS_MQXXX_DEFAULT_TYPE);
     #elif defined(HMS_MQXXX_PLATFORM_ESP_IDF)
       HMS_MQXXX(uint8_t pin = 36, HMS_MQXXX_Type type = HMS_MQXXX_DEFAULT_TYPE);
     #elif defined(HMS_MQXXX_PLATFORM_ZEPHYR)
@@ -149,10 +149,9 @@ class HMS_MQXXX {
       uint8_t         adcBitResolution    = 10;
       uint8_t         pin                 = 36;
     #elif defined(HMS_MQXXX_PLATFORM_STM32_HAL)
-      float           voltageResolution   = 3.3;  
-      uint8_t         adcBitResolution    = 12;
-      uint32_t        pin                 = 0;
-      GPIO_TypeDef    *port               = NULL;
+      float             voltageResolution   = 3.3;  
+      uint8_t           adcBitResolution    = 12;
+      ADC_HandleTypeDef *MQXXX_hadc;
     #endif
             
     bool                        firstFlag           = false;                // Flag for first initialization

--- a/src/HMS_MQXX_DRIVER.cpp
+++ b/src/HMS_MQXX_DRIVER.cpp
@@ -13,13 +13,28 @@ HMS_MQXXX_StatusTypeDef HMS_MQXXX::init() {
 }
 
 #elif defined(HMS_MQXXX_PLATFORM_STM32_HAL)
-HMS_MQXXX::HMS_MQXXX(GPIO_TypeDef *port, uint32_t pin, HMS_MQXXX_Type type) : port(port), pin(pin), type(type) {
+HMS_MQXXX::HMS_MQXXX(ADC_HandleTypeDef *hadc, HMS_MQXXX_Type type) : type(type) {
   setDefaultValues();
+  MQXXX_hadc = hadc;
+  init();
 }
 
 HMS_MQXXX_StatusTypeDef HMS_MQXXX::init() {
   // For STM32, ADC is already configured in CubeMX
+   if(MQXXX_hadc == NULL){
+    return HMS_MQXXX_ERROR;
+  }
+  setA(a);
+  setB(b);
+  setRegressionMethod(regression);
+  float calcR0 = 0;
+  for(int i = 0; i<=HMS_CALIBRATIION_SAMPLES; i++)
+    {
+      calcR0 += calibrate(HMS_MQXXX_MQ2_CLEAN_AIR_RATIO,0);
+    }
+  setR0(calcR0/HMS_CALIBRATIION_SAMPLES);  
   // Just initialize any required variables
+  readSensor()
   return HMS_MQXXX_OK;
 }
 
@@ -144,8 +159,10 @@ float HMS_MQXXX::getVoltage(bool read, bool injected, int value) {
             adc = analogRead(pin);
         #elif defined(HMS_MQXXX_PLATFORM_STM32_HAL)
             // STM32 HAL ADC reading - assumes ADC is configured in CubeMX
-            // adc = HAL_ADC_GetValue(&hadc1); // User needs to adapt this
-            adc = 2048; // Placeholder - needs actual HAL implementation
+            HAL_ADC_Start(MQXXX_hadc);
+            HAL_ADC_PollForConversion(&MQXXX_hadc, 10);
+            adc = HAL_ADC_GetValue(MQXXX_hadc); // User needs to adapt this
+            //adc = 2048; // Placeholder - needs actual HAL implementation
         #elif defined(HMS_MQXXX_PLATFORM_ESP_IDF)
             // ESP-IDF ADC reading - needs ADC configuration
             adc = 2048; // Placeholder - needs actual ESP-IDF implementation
@@ -156,6 +173,10 @@ float HMS_MQXXX::getVoltage(bool read, bool injected, int value) {
         avg += adc;
         mqDelay(retryInterval);
     }
+    #if defined(HMS_MQXXX_PLATFORM_STM32_HAL)
+    HAL_ADC_Stop(MQXXX_hadc);
+    #endif
+
     voltage = (avg / retries) * voltageResolution / ((pow(2, adcBitResolution)) - 1);
     sensorVolt = voltage; // Update the sensor voltage
   }


### PR DESCRIPTION
Updated STM32 HAL support in MQXXX driver:
1. Modified constructor to accept ADC handler and call init()
2. Added null check for ADC handler in init()
3. Set default A, B, and regression values using setter functions
4. Calculated average R0 value from multiple calibration samples
5. Called readSensor() after initialization
6. Updated getVoltage() to start and stop ADC